### PR TITLE
Warning patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@ set(32BLIT_PATH "../" CACHE PATH "Path to 32blit.cmake")
 set(PROJECT_SOURCE game.cpp game.hpp)
 
 # Build configuration; approach this with caution!
+if(MSVC)
+  add_compile_options("/W4" "/O2")
+else()
+  add_compile_options("-Wall" "-Wextra" "-Wdouble-promotion" "-Os")
+endif()
 if(NOT EXISTS ${32BLIT_PATH}/32blit.cmake)
   message(FATAL_ERROR "Define location of 32Blit API with -D32BLIT_PATH=<path to 32blit.cmake>")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(PROJECT_SOURCE game.cpp game.hpp)
 
 # Build configuration; approach this with caution!
 if(MSVC)
-  add_compile_options("/W4" "/O2")
+  add_compile_options("/W4" "/wd4244" "/wd4324" "/O2")
 else()
   add_compile_options("-Wall" "-Wextra" "-Wdouble-promotion" "-Os")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,4 +18,5 @@ include (${32BLIT_PATH}/32blit.cmake)
 blit_executable (${PROJECT_NAME} ${PROJECT_SOURCE})
 blit_assets_yaml (${PROJECT_NAME} assets.yml)
 blit_metadata (${PROJECT_NAME} metadata.yml)
+add_custom_target (flash DEPENDS ${PROJECT_NAME}.flash)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,9 @@ set(PROJECT_SOURCE game.cpp game.hpp)
 
 # Build configuration; approach this with caution!
 if(MSVC)
-  add_compile_options("/W4" "/wd4244" "/wd4324" "/O2")
+  add_compile_options("/W4" "/wd4244" "/wd4324")
 else()
-  add_compile_options("-Wall" "-Wextra" "-Wdouble-promotion" "-Os")
+  add_compile_options("-Wall" "-Wextra" "-Wdouble-promotion")
 endif()
 if(NOT EXISTS ${32BLIT_PATH}/32blit.cmake)
   message(FATAL_ERROR "Define location of 32Blit API with -D32BLIT_PATH=<path to 32blit.cmake>")


### PR DESCRIPTION
stm32 builds treat double-promotion warnings as errors (so breaking builds for that platform), but default warnings on Linux don't even mention them.

So, I've added it as a warning under Linux to try and spot problems before they bite builds on other platforms. I've also extended warnings on both Windows and non-Windows platforms as high as I can bear, on the basis that it teaches (forces?) people to keep their own code clean. 