### PR TITLE
Fix VS releases actually being debug builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
       shell: bash
       working-directory: ${{runner.workspace}}/main/build
       run: |
-        cmake --build . --target package
+        cmake --build . --config $BUILD_TYPE --target package
 
     # Push the tar file to the release
     - name: Upload tar


### PR DESCRIPTION
The CMake VS generator creates a VS solution with all the configs (instead of just the specified one) and we were only specifying the config at the build step. This resulted in release actions doing a Release build... then doing a Debug build and packaging that.

32blit-sdk likely needs the same fix.