### PR TITLE
Ignore more build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 build/
-build.em/
-build.stm32/
+build.*/


### PR DESCRIPTION
Discovered that I could use `"cmake.buildDirectory": "${workspaceFolder}/build.${buildKit}",` in VS Code to keep around multiple build dirs. That creates `build.__unspec__` and `build.32blit` though, so needed to extend the gitignore.

(Probably something like `build.Visual Studio [version] [platform]` on Windows...)