### PR TITLE
Bump Emscripten version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   BUILD_TYPE: Release
-  EM_VERSION: 2.0.4 # Emscripten version
+  EM_VERSION: 2.0.18 # Emscripten version
   EM_CACHE_FOLDER: 'emsdk-cache' # Cache for Emscripten libs
 
 jobs:


### PR DESCRIPTION
https://github.com/32blit/32blit-sdk/pull/682, but for the boilerplate.