### PR TITLE
Merge picosystem build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,14 @@ jobs:
             apt-packages: gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib python3-setuptools
 
           - os: ubuntu-20.04
+            pico-sdk: true
+            name: PicoSystem
+            cache-key: picosystem
+            release-suffix: PicoSystem
+            cmake-args: -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/32blit-sdk/pico.toolchain -DPICO_BOARD=pimoroni_picosystem
+            apt-packages: gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib python3-setuptools
+
+          - os: ubuntu-20.04
             name: Emscripten
             release-suffix: WEB
             cmake-args: -D32BLIT_DIR=$GITHUB_WORKSPACE/32blit-sdk
@@ -74,6 +82,15 @@ jobs:
       with:
         repository: 32blit/32blit-sdk
         path: 32blit-sdk
+
+    # pico sdk for some builds
+    - name: Checkout Pico SDK
+      if: matrix.pico-sdk
+      uses: actions/checkout@v2
+      with:
+        repository: raspberrypi/pico-sdk
+        path: pico-sdk
+        submodules: true
 
     # Linux dependencies
     - name: Install Linux deps


### PR DESCRIPTION
The picosystem-boilerplate is getting out of sync. Also, supporting the hardware that you can actually buy is probably a good idea.

(picosystem-boilerplate still has better docs, but at least some of that is duplicated in the SDK?)